### PR TITLE
feat: add hosted mode support for Spoolman shell embedding

### DIFF
--- a/src/components/AppNavbar.vue
+++ b/src/components/AppNavbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 import { Icon } from '@iconify/vue';
@@ -12,6 +12,7 @@ const props = defineProps<{
   pinnedCount: number;
   isConnected: boolean;
   hasUrl: boolean;
+  isHosted?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -26,6 +27,7 @@ const route = useRoute();
 const router = useRouter();
 
 const mobileMenuOpen = ref(false);
+const appTitle = computed(() => (props.isHosted ? t('app.hostedTitle') : t('app.title')));
 
 const handleOpenUrlDialog = () => {
   emit('openUrlDialog');
@@ -41,7 +43,7 @@ const handleOpenChangelog = () => {
 <template>
   <nav class="sticky top-0 z-40 bg-[rgb(var(--background))] flex items-center justify-between gap-2 sm:gap-4 px-2 sm:px-6 py-2 sm:py-4 pb-3 shrink-0 border-b">
     <div class="flex items-center gap-2 sm:gap-3 min-w-0">
-      <h1 class="text-base sm:text-xl font-semibold truncate">{{ t("app.title") }}</h1>
+      <h1 class="text-base sm:text-xl font-semibold truncate">{{ appTitle }}</h1>
     </div>
     
     <div class="flex items-center gap-1 sm:gap-2 shrink-0">
@@ -89,6 +91,7 @@ const handleOpenChangelog = () => {
       
       <!-- Desktop: Server button -->
       <Button
+        v-if="!props.isHosted"
         size="sm"
         variant="outline"
         @click="emit('openUrlDialog')"
@@ -115,7 +118,7 @@ const handleOpenChangelog = () => {
       <!-- Desktop: Show all buttons -->
       <div class="hidden sm:flex items-center gap-2">
         <LocaleSwitch />
-        <ThemeSwitch />
+        <ThemeSwitch v-if="!props.isHosted" />
       </div>
       
       <Button
@@ -186,6 +189,7 @@ const handleOpenChangelog = () => {
             >
               <div class="p-2 flex flex-col gap-1">
                 <button 
+                  v-if="!props.isHosted"
                   class="flex items-center gap-2 px-3 py-2 text-sm hover:bg-[rgb(var(--surface-alt))] rounded-md transition-colors"
                   @click="handleOpenUrlDialog"
                 >
@@ -207,7 +211,7 @@ const handleOpenChangelog = () => {
                   Spoolman Server
                 </button>
                 <hr class="border-border/50 my-1" />
-                <div class="flex items-center justify-between px-3 py-2">
+                <div v-if="!props.isHosted" class="flex items-center justify-between px-3 py-2">
                   <span class="text-xs text-[rgb(var(--text-muted))]">Theme</span>
                   <ThemeSwitch />
                 </div>

--- a/src/composables/useFilaments.ts
+++ b/src/composables/useFilaments.ts
@@ -150,7 +150,7 @@ const createFilamentsComposable = () => {
   const spoolmanMaterials = ref<SpoolmanMaterial[]>([]);
   const spoolmanVendors = ref<SpoolmanVendor[]>([]);
   const spoolmanLocations = ref<string[]>([]);
-  const { resolvedBaseUrl, hasUrl } = useSpoolmanUrl();
+  const { resolvedBaseUrl, hasUrl, isHosted } = useSpoolmanUrl();
 
   // Read query parameters from URL (case-insensitive)
   const urlParams = new URLSearchParams(window.location.search);
@@ -179,8 +179,9 @@ const createFilamentsComposable = () => {
     try {
       const baseUrl = resolvedBaseUrl.value;
 
-      // Only load Spoolman data if a URL is configured
-      const shouldLoadSpoolman = hasUrl.value && baseUrl.trim().length > 0;
+      // Hosted shells can legitimately provide an empty root base path, so use
+      // the hosted flag instead of treating an empty string as "not configured."
+      const shouldLoadSpoolman = hasUrl.value && (isHosted.value || baseUrl.trim().length > 0);
       // Only load external data sources if not filtering for spoolman only
       const shouldLoadExternal = filters.source !== "spoolman";
 

--- a/src/composables/useHostedMode.ts
+++ b/src/composables/useHostedMode.ts
@@ -6,7 +6,7 @@ export type HostedConfig = {
   app_base_path: string;
 };
 
-type HostedWindow = Window & {
+export type HostedWindow = Window & {
   __SPOOLMAN_HOSTED__?: HostedConfig;
   __SPOOLMAN_HOSTED_THEME__?: "light" | "dark";
 };

--- a/src/composables/useHostedMode.ts
+++ b/src/composables/useHostedMode.ts
@@ -1,0 +1,26 @@
+export type HostedConfig = {
+  contract_version: number;
+  mode: "hosted";
+  app_key: string;
+  spoolman_base_url: string;
+  app_base_path: string;
+};
+
+type HostedWindow = Window & {
+  __SPOOLMAN_HOSTED__?: HostedConfig;
+  __SPOOLMAN_HOSTED_THEME__?: "light" | "dark";
+};
+
+export const getHostedConfig = () => (window as HostedWindow).__SPOOLMAN_HOSTED__ ?? null;
+
+export const isHostedMode = () => Boolean(getHostedConfig() || new URLSearchParams(window.location.search).get("spoolman_hosted"));
+
+export const getHostedTheme = () => {
+  const hostedTheme = (window as HostedWindow).__SPOOLMAN_HOSTED_THEME__;
+  if (hostedTheme === "light" || hostedTheme === "dark") {
+    return hostedTheme;
+  }
+
+  const queryTheme = new URLSearchParams(window.location.search).get("spoolman_theme");
+  return queryTheme === "light" || queryTheme === "dark" ? queryTheme : null;
+};

--- a/src/composables/useHostedMode.ts
+++ b/src/composables/useHostedMode.ts
@@ -13,7 +13,7 @@ type HostedWindow = Window & {
 
 export const getHostedConfig = () => (window as HostedWindow).__SPOOLMAN_HOSTED__ ?? null;
 
-export const isHostedMode = () => Boolean(getHostedConfig() || new URLSearchParams(window.location.search).get("spoolman_hosted"));
+export const isHostedMode = () => Boolean(getHostedConfig());
 
 export const getHostedTheme = () => {
   const hostedTheme = (window as HostedWindow).__SPOOLMAN_HOSTED_THEME__;

--- a/src/composables/useSpoolmanUrl.ts
+++ b/src/composables/useSpoolmanUrl.ts
@@ -1,6 +1,6 @@
 import { computed, ref, watch } from "vue";
 import { DEFAULT_SPOOLMAN_URL } from "../api/spoolman";
-import { getHostedConfig, isHostedMode } from "./useHostedMode";
+import { getHostedConfig, isHostedMode, type HostedConfig } from "./useHostedMode";
 
 const STORAGE_KEY = "spoolman-url";
 const hasWindow = typeof window !== "undefined";
@@ -77,6 +77,11 @@ const setSpoolmanUrl = (value: string) => {
 const resetSpoolmanUrl = () => {
     if (isHostedMode()) return;
     setSpoolmanUrl(DEFAULT_SPOOLMAN_URL);
+};
+
+export const rehydrateFromHostedConfig = (hostedConfig: HostedConfig | null) => {
+    if (!hostedConfig) return;
+    spoolmanUrl.value = hostedConfig.spoolman_base_url;
 };
 
 const resolvedBaseUrl = computed(() => {

--- a/src/composables/useSpoolmanUrl.ts
+++ b/src/composables/useSpoolmanUrl.ts
@@ -1,11 +1,19 @@
 import { computed, ref, watch } from "vue";
 import { DEFAULT_SPOOLMAN_URL } from "../api/spoolman";
+import { getHostedConfig, isHostedMode } from "./useHostedMode";
 
 const STORAGE_KEY = "spoolman-url";
 const hasWindow = typeof window !== "undefined";
 
 const readStored = () => {
     if (!hasWindow) return DEFAULT_SPOOLMAN_URL;
+
+    const hostedConfig = getHostedConfig();
+    if (hostedConfig) {
+        // Hosted mode always follows the parent Spoolman instance instead of any
+        // remembered standalone URL, which avoids cross-instance drift.
+        return hostedConfig.spoolman_base_url;
+    }
 
     // Check for URL in query string first (surl parameter)
     try {
@@ -50,6 +58,9 @@ watch(spoolmanUrl, (value) => {
 
 const persist = (value: string) => {
     if (!hasWindow) return;
+    // The embedded app should not overwrite local standalone preferences while it is
+    // running under the Spoolman shell.
+    if (isHostedMode()) return;
     try {
         window.localStorage.setItem(STORAGE_KEY, value);
     } catch (err) {
@@ -64,10 +75,16 @@ const setSpoolmanUrl = (value: string) => {
 };
 
 const resetSpoolmanUrl = () => {
+    if (isHostedMode()) return;
     setSpoolmanUrl(DEFAULT_SPOOLMAN_URL);
 };
 
 const resolvedBaseUrl = computed(() => {
+    const hostedConfig = getHostedConfig();
+    if (hostedConfig) {
+        return hostedConfig.spoolman_base_url;
+    }
+
     // If the target is spoolman.disane.dev, use the local dev proxy to avoid CORS (only in development).
     if (import.meta.env.DEV) {
         try {
@@ -83,6 +100,12 @@ const resolvedBaseUrl = computed(() => {
 });
 
 const hasUrl = computed(() => {
+    const hostedConfig = getHostedConfig();
+    if (hostedConfig) {
+        // Embedded launches already proved the parent instance, even when it is
+        // mounted at the site root and the base path is the empty string.
+        return true;
+    }
     return spoolmanUrl.value.trim().length > 0;
 });
 
@@ -90,6 +113,7 @@ export const useSpoolmanUrl = () => ({
     spoolmanUrl,
     resolvedBaseUrl,
     hasUrl,
+    isHosted: computed(() => isHostedMode()),
     setSpoolmanUrl,
     resetSpoolmanUrl,
 });

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -1,4 +1,5 @@
 import { ref, watch } from "vue";
+import { getHostedTheme, isHostedMode } from "./useHostedMode";
 
 const THEME_KEY = "theme";
 type ThemeMode = "light" | "dark" | "system";
@@ -12,11 +13,29 @@ const applyTheme = (mode: ThemeMode) => {
 };
 
 export const setupTheme = () => {
+  const hostedTheme = getHostedTheme();
+  if (isHostedMode() && (hostedTheme === "light" || hostedTheme === "dark")) {
+    applyTheme(hostedTheme);
+    return;
+  }
+
   const stored = (localStorage.getItem(THEME_KEY) as ThemeMode) ?? "system";
   applyTheme(stored);
 };
 
 export const useTheme = () => {
+  const hostedTheme = getHostedTheme();
+  if (isHostedMode() && (hostedTheme === "light" || hostedTheme === "dark")) {
+    const mode = ref<ThemeMode>(hostedTheme);
+    return {
+      mode,
+      setMode: () => {
+        // Hosted mode mirrors the parent Spoolman shell and does not expose
+        // an independent theme preference inside the embedded app.
+      },
+    };
+  }
+
   const stored = (localStorage.getItem(THEME_KEY) as ThemeMode) ?? "system";
   const mode = ref<ThemeMode>(stored);
 

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1,6 +1,7 @@
 {
   "app": {
     "title": "Spool Swatch",
+    "hostedTitle": "Filament Swatch",
     "subtitle": "Lokaler Farbpicker fuer Filamente und Spulen",
     "tagline": "Wische durch Farben, finde Materialien und merke dir perfekte Matches.",
     "footer": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,7 @@
 {
   "app": {
     "title": "Spool Swatch",
+    "hostedTitle": "Filament Swatch",
     "subtitle": "Local color picker for filaments and spools",
     "tagline": "Swipe through colors, find materials, and remember perfect matches.",
     "footer": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,26 +7,76 @@ import de from "./locales/de.json";
 import en from "./locales/en.json";
 import { setupTheme } from "./composables/useTheme";
 
-const savedLocale = localStorage.getItem("locale") ?? "de";
+type HostedConfig = {
+  contract_version: number;
+  mode: "hosted";
+  app_key: string;
+  spoolman_base_url: string;
+  app_base_path: string;
+};
 
-const i18n = createI18n({
-  legacy: false,
-  locale: savedLocale,
-  messages: {
-    de,
-    en,
-  },
-});
+type HostedWindow = Window & {
+  __SPOOLMAN_HOSTED__?: HostedConfig;
+  __SPOOLMAN_HOSTED_THEME__?: "light" | "dark";
+};
 
-setupTheme();
+const getQueryParam = (name: string) => new URLSearchParams(window.location.search).get(name);
 
-// Analytics - nur in Produktion laden
-if (import.meta.env.MODE !== 'development') {
-  const script = document.createElement('script');
-  script.defer = true;
-  script.src = 'https://statistics.disane.dev/script.js';
-  script.setAttribute('data-website-id', '95c90cb7-c1d3-488c-a68b-4210a7d2c76c');
-  document.head.appendChild(script);
-}
+const loadHostedConfig = async () => {
+  const configUrl = getQueryParam("spoolman_hosted_config");
+  const hosted = getQueryParam("spoolman_hosted");
 
-createApp(App).use(i18n).use(router).mount("#app");
+  if (!hosted || !configUrl) {
+    return null;
+  }
+
+  // The host runtime serves this JSON from the same origin so the standalone app
+  // can switch into embedded mode without baking any Spoolman instance details.
+  const response = await fetch(configUrl);
+  if (!response.ok) {
+    throw new Error(`Could not load hosted config: ${response.status}`);
+  }
+
+  const config = (await response.json()) as HostedConfig;
+  (window as HostedWindow).__SPOOLMAN_HOSTED__ = config;
+  return config;
+};
+
+const bootstrap = async () => {
+  const hostedConfig = await loadHostedConfig().catch((error) => {
+    console.warn("Could not load Spoolman hosted config", error);
+    return null;
+  });
+
+  const hostedTheme = getQueryParam("spoolman_theme");
+  if (hostedTheme === "light" || hostedTheme === "dark") {
+    (window as HostedWindow).__SPOOLMAN_HOSTED_THEME__ = hostedTheme;
+  }
+
+  const localeFromHost = getQueryParam("spoolman_locale");
+  const savedLocale = localeFromHost || localStorage.getItem("locale") || "de";
+
+  const i18n = createI18n({
+    legacy: false,
+    locale: savedLocale,
+    messages: {
+      de,
+      en,
+    },
+  });
+
+  setupTheme();
+
+  // Hosted mode relies on the Spoolman shell for analytics and server discovery.
+  if (import.meta.env.MODE !== "development" && !hostedConfig) {
+    const script = document.createElement("script");
+    script.defer = true;
+    script.src = "https://statistics.disane.dev/script.js";
+    script.setAttribute("data-website-id", "95c90cb7-c1d3-488c-a68b-4210a7d2c76c");
+    document.head.appendChild(script);
+  }
+
+  createApp(App).use(i18n).use(router).mount("#app");
+};
+
+void bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { createApp } from "vue";
 import { createI18n } from "vue-i18n";
-import router from "./router";
+import { createAppRouter } from "./router";
 import App from "./App.vue";
 import "./styles.css";
 import de from "./locales/de.json";
@@ -66,6 +66,7 @@ const bootstrap = async () => {
   });
 
   setupTheme();
+  const router = createAppRouter();
 
   // Hosted mode relies on the Spoolman shell for analytics and server discovery.
   if (import.meta.env.MODE !== "development" && !hostedConfig) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,20 +5,9 @@ import App from "./App.vue";
 import "./styles.css";
 import de from "./locales/de.json";
 import en from "./locales/en.json";
+import { type HostedConfig, type HostedWindow } from "./composables/useHostedMode";
+import { rehydrateFromHostedConfig } from "./composables/useSpoolmanUrl";
 import { setupTheme } from "./composables/useTheme";
-
-type HostedConfig = {
-  contract_version: number;
-  mode: "hosted";
-  app_key: string;
-  spoolman_base_url: string;
-  app_base_path: string;
-};
-
-type HostedWindow = Window & {
-  __SPOOLMAN_HOSTED__?: HostedConfig;
-  __SPOOLMAN_HOSTED_THEME__?: "light" | "dark";
-};
 
 const getQueryParam = (name: string) => new URLSearchParams(window.location.search).get(name);
 
@@ -47,6 +36,7 @@ const bootstrap = async () => {
     console.warn("Could not load Spoolman hosted config", error);
     return null;
   });
+  rehydrateFromHostedConfig(hostedConfig);
 
   const hostedTheme = getQueryParam("spoolman_theme");
   if (hostedTheme === "light" || hostedTheme === "dark") {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,78 +5,79 @@ import ProjectsView from '@/views/ProjectsView.vue';
 import ProjectDetailView from '@/views/ProjectDetailView.vue';
 import { isHostedMode } from '@/composables/useHostedMode';
 
-const hostedMode = isHostedMode();
 const hostedRoot = '/app/swatch';
 const hostedTitle = 'Filament Swatch';
 const standaloneTitle = 'Spool Swatch';
-const titlePrefix = hostedMode ? hostedTitle : standaloneTitle;
+export const createAppRouter = () => {
+  const hostedMode = isHostedMode();
+  const titlePrefix = hostedMode ? hostedTitle : standaloneTitle;
 
-const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
-  routes: [
-    hostedMode
-      ? {
-          path: '/',
-          redirect: hostedRoot,
-        }
-      : {
-          path: '/',
-          name: 'landing',
-          component: LandingPage,
-          meta: {
-            title: `${titlePrefix} - Your 3D Printing Filament Color Browser`
+  const router = createRouter({
+    history: createWebHistory(import.meta.env.BASE_URL),
+    routes: [
+      hostedMode
+        ? {
+            path: '/',
+            redirect: hostedRoot,
           }
-        },
-    {
-      path: '/app',
-      component: MainApp,
-      redirect: hostedRoot,
-      children: [
-        {
-          path: 'swatch',
-          name: 'swatch',
-          component: () => import('@/views/FilamentsView.vue'),
-          meta: {
-            title: `${titlePrefix} - Browse Your Collection`
+        : {
+            path: '/',
+            name: 'landing',
+            component: LandingPage,
+            meta: {
+              title: `${titlePrefix} - Your 3D Printing Filament Color Browser`
+            }
+          },
+      {
+        path: '/app',
+        component: MainApp,
+        redirect: hostedRoot,
+        children: [
+          {
+            path: 'swatch',
+            name: 'swatch',
+            component: () => import('@/views/FilamentsView.vue'),
+            meta: {
+              title: `${titlePrefix} - Browse Your Collection`
+            }
+          },
+          {
+            path: 'projects',
+            name: 'projects',
+            component: ProjectsView,
+            meta: {
+              title: `${titlePrefix} - Projects`
+            }
+          },
+          {
+            path: 'projects/:id',
+            name: 'project-detail',
+            component: ProjectDetailView,
+            meta: {
+              title: `${titlePrefix} - Project Details`
+            }
           }
-        },
-        {
-          path: 'projects',
-          name: 'projects',
-          component: ProjectsView,
-          meta: {
-            title: `${titlePrefix} - Projects`
-          }
-        },
-        {
-          path: 'projects/:id',
-          name: 'project-detail',
-          component: ProjectDetailView,
-          meta: {
-            title: `${titlePrefix} - Project Details`
-          }
-        }
-      ]
-    },
-    // Catch-all redirect for unknown routes
-    {
-      path: '/:pathMatch(.*)*',
-      redirect: hostedMode ? hostedRoot : '/'
+        ]
+      },
+      // Catch-all redirect for unknown routes
+      {
+        path: '/:pathMatch(.*)*',
+        redirect: hostedMode ? hostedRoot : '/'
+      }
+    ],
+    scrollBehavior(to, from, savedPosition) {
+      if (savedPosition) {
+        return savedPosition;
+      } else {
+        return { top: 0 };
+      }
     }
-  ],
-  scrollBehavior(to, from, savedPosition) {
-    if (savedPosition) {
-      return savedPosition;
-    } else {
-      return { top: 0 };
-    }
-  }
-});
+  });
 
-// Update document title on route change
-router.beforeEach((to, from, next) => {
-  document.title = (to.meta.title as string) || titlePrefix;
-  next();
-});
+  router.beforeEach((to, from, next) => {
+    document.title = (to.meta.title as string) || titlePrefix;
+    next();
+  });
 
-export default router;
+  return router;
+};

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,29 +3,41 @@ import { LandingPage } from '@/components/landing';
 import MainApp from '@/views/MainApp.vue';
 import ProjectsView from '@/views/ProjectsView.vue';
 import ProjectDetailView from '@/views/ProjectDetailView.vue';
+import { isHostedMode } from '@/composables/useHostedMode';
+
+const hostedMode = isHostedMode();
+const hostedRoot = '/app/swatch';
+const hostedTitle = 'Filament Swatch';
+const standaloneTitle = 'Spool Swatch';
+const titlePrefix = hostedMode ? hostedTitle : standaloneTitle;
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
-    {
-      path: '/',
-      name: 'landing',
-      component: LandingPage,
-      meta: {
-        title: 'Spool Swatch - Your 3D Printing Filament Color Browser'
-      }
-    },
+    hostedMode
+      ? {
+          path: '/',
+          redirect: hostedRoot,
+        }
+      : {
+          path: '/',
+          name: 'landing',
+          component: LandingPage,
+          meta: {
+            title: `${titlePrefix} - Your 3D Printing Filament Color Browser`
+          }
+        },
     {
       path: '/app',
       component: MainApp,
-      redirect: '/app/swatch',
+      redirect: hostedRoot,
       children: [
         {
           path: 'swatch',
           name: 'swatch',
           component: () => import('@/views/FilamentsView.vue'),
           meta: {
-            title: 'Spool Swatch - Browse Your Collection'
+            title: `${titlePrefix} - Browse Your Collection`
           }
         },
         {
@@ -33,7 +45,7 @@ const router = createRouter({
           name: 'projects',
           component: ProjectsView,
           meta: {
-            title: 'Spool Swatch - Projects'
+            title: `${titlePrefix} - Projects`
           }
         },
         {
@@ -41,7 +53,7 @@ const router = createRouter({
           name: 'project-detail',
           component: ProjectDetailView,
           meta: {
-            title: 'Spool Swatch - Project Details'
+            title: `${titlePrefix} - Project Details`
           }
         }
       ]
@@ -49,7 +61,7 @@ const router = createRouter({
     // Catch-all redirect for unknown routes
     {
       path: '/:pathMatch(.*)*',
-      redirect: '/'
+      redirect: hostedMode ? hostedRoot : '/'
     }
   ],
   scrollBehavior(to, from, savedPosition) {
@@ -63,7 +75,7 @@ const router = createRouter({
 
 // Update document title on route change
 router.beforeEach((to, from, next) => {
-  document.title = (to.meta.title as string) || 'Spool Swatch';
+  document.title = (to.meta.title as string) || titlePrefix;
   next();
 });
 

--- a/src/views/MainApp.vue
+++ b/src/views/MainApp.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mx-auto flex h-screen flex-col overflow-hidden">
     <!-- Main Content Wrapper (gets blurred when panels are open) -->
-    <div class="main-content-wrapper" :class="{ blurred: paletteOpen || selectedFilament }">
+    <div class="main-content-wrapper flex min-h-0 flex-1 flex-col" :class="{ blurred: paletteOpen || selectedFilament }">
       <!-- Top Navigation Bar -->
       <AppNavbar
         :projects-count="projectsCount"
@@ -16,7 +16,10 @@
       />
 
       <!-- Router Outlet -->
-      <div class="router-content px-3 sm:px-6 py-1 sm:py-2">
+      <div
+        class="router-content flex-1 min-h-0 overflow-y-auto"
+        :class="isHosted ? 'px-3 sm:px-4 py-1 sm:py-1.5' : 'px-3 sm:px-6 py-1 sm:py-2'"
+      >
         <RouterView class="flex-1 min-h-0" />
       </div>
 

--- a/src/views/MainApp.vue
+++ b/src/views/MainApp.vue
@@ -8,6 +8,7 @@
         :pinned-count="pinnedItems.length"
         :is-connected="isConnected"
         :has-url="hasUrl"
+        :is-hosted="isHosted"
         @open-url-dialog="openUrlDialog"
         @open-palette="paletteOpen = true"
         @open-changelog="openChangelog"
@@ -20,7 +21,7 @@
       </div>
 
       <!-- App Footer -->
-      <footer class="flex-shrink-0 border-t border-border/40 bg-[rgb(var(--background))]/80 backdrop-blur-sm">
+      <footer v-if="!isHosted" class="flex-shrink-0 border-t border-border/40 bg-[rgb(var(--background))]/80 backdrop-blur-sm">
         <div class="px-3 sm:px-6 py-3 flex flex-col sm:flex-row items-center justify-between gap-2 text-xs text-[rgb(var(--text-muted))]">
           <div class="flex items-center gap-4">
             <span class="flex items-center gap-1.5">
@@ -131,7 +132,7 @@
     </div>
 
     <!-- URL Dialog -->
-    <Dialog v-model:open="urlDialogOpen">
+    <Dialog v-if="!isHosted" v-model:open="urlDialogOpen">
       <DialogContent class="sm:max-w-md" :onInteractOutside="(e) => { if (!hasUrl) e.preventDefault(); }">
         <DialogHeader>
           <DialogTitle>{{ t("dialog.spoolmanUrlTitle") }}</DialogTitle>
@@ -245,6 +246,7 @@ import { useI18n } from "vue-i18n";
 import { useRouter, RouterView } from "vue-router";
 import { useSeo } from "../composables/useSeo";
 import { useSpoolmanUrl } from "../composables/useSpoolmanUrl";
+import { isHostedMode } from "../composables/useHostedMode";
 import { getProjects } from "../api/projects";
 import { useFilaments } from "../composables/useFilaments";
 import AppNavbar from "../components/AppNavbar.vue";
@@ -370,6 +372,7 @@ const scrollToPinned = (id: string) => {
 };
 
 const { spoolmanUrl, setSpoolmanUrl, resetSpoolmanUrl, hasUrl } = useSpoolmanUrl();
+const isHosted = isHostedMode();
 const urlDialogOpen = ref(false);
 const spoolmanUrlInput = ref(spoolmanUrl.value);
 const connectionChecking = ref(false);
@@ -385,6 +388,10 @@ const currentDomain = computed(() => {
 });
 
 const openUrlDialog = async () => {
+  if (isHosted) {
+    return;
+  }
+
   spoolmanUrlInput.value = spoolmanUrl.value;
   connectionStatus.value = null;
   urlDialogOpen.value = true;
@@ -428,6 +435,10 @@ const applySpoolmanUrl = async () => {
 };
 
 const resetUrlToDefault = () => {
+  if (isHosted) {
+    return;
+  }
+
   resetSpoolmanUrl();
   spoolmanUrlInput.value = spoolmanUrl.value;
   urlDialogOpen.value = false;
@@ -462,10 +473,10 @@ useSeo(
 );
 
 onMounted(async () => {
-  if (!hasUrl.value) {
+  if (!hasUrl.value && !isHosted) {
     urlDialogOpen.value = true;
   } else {
-    // Check connection status on mount
+    // Hosted mode bypasses the server-picker flow and refreshes directly against the injected API base.
     await checkConnection(spoolmanUrl.value);
     refresh();
   }
@@ -476,4 +487,3 @@ onMounted(async () => {
   }
 });
 </script>
-

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,27 @@
 import path from "node:path";
-import { defineConfig } from "vite";
+import { defineConfig, type PluginOption } from "vite";
 import vue from "@vitejs/plugin-vue";
 import tailwindcss from "@tailwindcss/vite";
 
+const hostedMode = process.env.VITE_HOSTED_MODE === "1";
+
+const hostedIndexPlugin: PluginOption = {
+  name: "hosted-index-shell",
+  transformIndexHtml(html) {
+    if (!hostedMode) {
+      return html;
+    }
+
+    return html
+      .replace(/\s*<link rel="manifest"[^>]*>\n?/g, "")
+      .replace(/\s*<link rel="search"[^>]*>\n?/g, "")
+      .replace(/\s*<link rel="canonical"[^>]*>\n?/g, "");
+  },
+};
+
 export default defineConfig({
-  base: '/',
-  plugins: [vue(), tailwindcss()],
+  base: process.env.VITE_BASE_PATH || "/",
+  plugins: [vue(), tailwindcss(), hostedIndexPlugin],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary

Adds a focused hosted-mode path so spoolman-filament-swatch can run cleanly inside the Spoolman Applications Framework as a same-origin embedded app while preserving standalone mode.

This branch is intended to pair with the hosted-shell work happening in akira69/Spoolman_Labels on feat/hosted-applications-framework-workspace.

## What Changed

- add hosted-mode route defaults so embedded launches land on /app/swatch
- add hosted-mode title/branding support so the app reads as Filament Swatch when embedded
- strip standalone-only manifest/search/canonical links from hosted builds
- accept host-provided theme state and mirror the parent shell instead of exposing a separate theme selector
- treat hosted config as authoritative for backend/API access
- allow hosted mode to load Spoolman data correctly from root or subpath deployments
- fix stale spoolmanUrl on first render: useSpoolmanUrl is a module-level singleton evaluated before bootstrap() resolves — rehydrateFromHostedConfig() corrects it after the async hosted config is fetched, before any connection check fires
- deduplicate HostedConfig/HostedWindow types: export from useHostedMode.ts; main.ts imports rather than re-declaring them

## Hosted Runtime Behavior

When launched by a host shell, the app now:

- reads a small hosted config payload from the parent runtime
- uses host-provided Spoolman base-path context
- follows the parent dark/light mode
- hides the standalone theme switch
- skips standalone landing-path assumptions
- preserves standalone behavior when no hosted config is present

## Verification

Verified locally against a same-origin Spoolman host shell on 2026-03-23:

- hosted app launched under /app-host/spoolman-filament-swatch/
- embedded route defaulted into the swatch UI
- embedded title rendered as Filament Swatch
- app-local theme selector was removed in hosted mode
- parent Spoolman dark mode propagated into the hosted app
- hosted app loaded seeded filament/spool data through the parent Spoolman instance

## Notes

- This PR intentionally keeps the changes narrow and host-oriented.
- It does not vendor Spoolman-specific code into the app beyond the small hosted contract path.
- The search-bar visibility fix on narrow widths is a separate concern tracked in PR #27.
- A remaining follow-up outside this repo is cleaning up the parent shell's nested-route service worker 404 in the browser console.
