### PR TITLE
fix: keep search visible on narrow widths

### DIFF
--- a/src/components/FiltersBar.vue
+++ b/src/components/FiltersBar.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="filters-container">
-    <!-- Search bar - only visible on desktop (md+) -->
-    <div class="hidden md:flex gap-2 items-center">
+    <div class="flex gap-2 items-center">
       <Input v-model="props.filters.search" type="search" :placeholder="searchPlaceholder" class="flex-1 h-10" />
       <Button variant="ghost" size="icon" @click="filtersVisible = !filtersVisible" aria-label="Toggle filters"
         class="h-10 w-10 shrink-0" :class="{ 'bg-[rgb(var(--accent))]': filtersVisible }">

--- a/src/styles.css
+++ b/src/styles.css
@@ -117,15 +117,9 @@ body {
 }
 
 .control-grid {
-  display: none;
+  display: flex;
   gap: 14px;
   align-items: start;
-}
-
-@media (min-width: 768px) {
-  .control-grid {
-    display: flex;
-  }
 }
 
 .mobile-menu {

--- a/src/views/FilamentsView.vue
+++ b/src/views/FilamentsView.vue
@@ -10,7 +10,7 @@
       </p>
     </header>
 
-    <div class="control-grid hidden md:flex">
+    <div class="control-grid">
       <div class="control-card glass">
         <FiltersBar
           :filters="filters"


### PR DESCRIPTION
## Summary

## Why
On the current mobile/narrow layout, the search UI disappears entirely. That makes the main browsing view much harder to use, especially once the collection grows.
<img width="445" height="276" alt="image" src="https://github.com/user-attachments/assets/a54acbad-6145-4c98-aa11-fba37317217b" />

## The Fix
- keep the search bar visible below the md breakpoint
- keep the filters panel available on narrow widths instead of hiding the entire controls block
- treat search as a primary control so the swatch view remains usable on smaller screens

## Notes
- advanced filters remain collapsible; this just keeps the primary search control available
